### PR TITLE
Enable tests for Windows with GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
         os:
         - ubuntu-latest
         - macOS-latest
-        # - windows-latest
+        - windows-latest
         gradle_task:
         - ":embulk-decoder-bzip2:check"
         - ":embulk-decoder-gzip:check"
@@ -31,11 +31,28 @@ jobs:
         - ":embulk-parser-csv:check"
         - ":embulk-parser-json:check"
     steps:
+    - name: Set Git's core.autocrlf to false for Windows before checkout
+      run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
     - name: Set up OpenJDK 8
       uses: actions/setup-java@v2
       with:
         java-version: 8
         distribution: "zulu"
+
+    # GitHub Actions on Windows set environment variables TMP and TEMP with a legacy DOS 8.3 filename: "C:\Users\RUNNER~1\..."
+    # On the other hand, "embulk-input-file" expects a long filename (LFN) on Windows.
+    #
+    # The following two steps override TMP and TEMP with LFN. USERPROFILE is set with LFN fortunately.
+    #
+    # See: https://github.com/actions/virtual-environments/issues/712
+
+    - name: Override TMP to use Windows' long filename (LFN)
+      run: echo "TMP=$env:USERPROFILE\AppData\Local\Temp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      if: matrix.os == 'windows-latest'
+    - name: Override TEMP to use Windows' long filename (LFN)
+      run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      if: matrix.os == 'windows-latest'
+
     - name: Build and test
       run: ./gradlew ${{ matrix.gradle_task }}


### PR DESCRIPTION
Finally! In the old https://github.com/embulk/embulk repository, Windows was tested by Appveyor, but we're going to discard Appveyor.

There were some blockers to run tests on GitHub Actions / Windows. This PR is to unblock it, and test them on Windows.