### PR TITLE
Test just once, not to run tests both for GitHub "push" and "pull_request"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,9 @@ on: [ pull_request, push ]
 jobs:
   check:
     runs-on: ${{ matrix.os }}
+    # push: always run.
+    # pull_request: run only when the PR is submitted from a forked repository, not within this repository.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It has so many test jobs, and they are doubled when we make a Pull Request for a branch under `embulk`. It's too much. Let's stop it.