### PR TITLE
Output verbose test logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,20 @@ task release {
 }
 
 subprojects {
+    tasks.withType(Test) {
+        testLogging {
+            events "passed", "skipped", "failed", "standardOut", "standardError"
+
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+            showStandardStreams = true
+
+            outputs.upToDateWhen { false }
+        }
+    }
+
     afterEvaluate { project ->
         rootProject.release.dependsOn project.publishMavenPublicationToMavenCentralRepository
     }


### PR DESCRIPTION
Its test logs were not sufficient (especially on GitHub Actions) to investigate test failures. This PR makes the test logs much verbose.