### PR TITLE
Re-enable tests for CSV Guess

### DIFF
--- a/embulk-guess-csv/src/test/java/org/embulk/guess/csv/TestCsvGuessPlugin.java
+++ b/embulk-guess-csv/src/test/java/org/embulk/guess/csv/TestCsvGuessPlugin.java
@@ -23,20 +23,15 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Tests CsvGuessPlugin.
  */
 public class TestCsvGuessPlugin {
-    @Rule
-    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
-
     @Test
     public void testLargeLong() {
         final ConfigDiff actual = guess(

--- a/embulk-guess-csv_all_strings/src/test/java/org/embulk/guess/csv/TestCsvAllStringsGuessPlugin.java
+++ b/embulk-guess-csv_all_strings/src/test/java/org/embulk/guess/csv/TestCsvAllStringsGuessPlugin.java
@@ -21,20 +21,15 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapperFactory;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Tests CsvAllStringsGuessPlugin.
  */
 public class TestCsvAllStringsGuessPlugin {
-    @Rule
-    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
-
     /*
     def test_columns_without_header
       actual = guess([

--- a/embulk-guess-csv_all_strings/src/test/java/org/embulk/guess/csv/TestCsvAllStringsGuessPlugin.java
+++ b/embulk-guess-csv_all_strings/src/test/java/org/embulk/guess/csv/TestCsvAllStringsGuessPlugin.java
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.spi.Buffer;
+import org.embulk.spi.BufferAllocator;
+import org.embulk.spi.BufferImpl;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.junit.Test;
 
@@ -98,12 +101,24 @@ public class TestCsvAllStringsGuessPlugin {
         assertEquals("string", columnsActual.get(2).get("type"));
     }
 
+    private static class MockBufferAllocator implements BufferAllocator {
+        @Override
+        public Buffer allocate() {
+            return this.allocate(32 * 1024);
+        }
+
+        @Override
+        public Buffer allocate(final int minimumCapacity) {
+            return BufferImpl.allocate(minimumCapacity);
+        }
+    }
+
     private static ConfigDiff guess(final String... sampleLines) {
         final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource();
         final ConfigSource parserConfig = CONFIG_MAPPER_FACTORY.newConfigSource();
         parserConfig.set("type", "csv");
         config.set("parser", parserConfig);
-        return new CsvAllStringsGuessPlugin().guessLines(config, Arrays.asList(sampleLines));
+        return new CsvAllStringsGuessPlugin().guessLines(config, Arrays.asList(sampleLines), new MockBufferAllocator());
     }
 
     private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();


### PR DESCRIPTION
It turned out that the tests for `embulk-guess-csv` have not been working well (all successful without running actual test code) due to unexpected problems with `@Rule` and `EmbulkTestRuntime`.

Then, this pull-request :
* ed1390798d243c5a08acaf359315322a204e89bc: Removes `@Rule EmbulkTestRuntime` to reveal the test errors. (Tests fail.)
* fd3b8d44c1e34d14bb870054946a87b3074e0b99: Fixes a hidden problem which was caused by calling `Exec.getBufferAllocator()` out of `Exec.doWith`. (Tests succeed.)
