### PR TITLE
Bump up to v0.10.36-SNAPSHOT

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,26 +13,6 @@ jobs:
         - ubuntu-latest
         - macOS-latest
         - windows-latest
-        gradle_task:
-        - ":embulk-decoder-bzip2:check"
-        - ":embulk-decoder-gzip:check"
-        - ":embulk-encoder-bzip2:check"
-        - ":embulk-encoder-gzip:check"
-        - ":embulk-filter-remove_columns:check"
-        - ":embulk-filter-rename:check"
-        - ":embulk-formatter-csv:check"
-        - ":embulk-guess-bzip2:check"
-        - ":embulk-guess-csv:check"
-        - ":embulk-guess-csv_all_strings:check"
-        - ":embulk-guess-gzip:check"
-        - ":embulk-guess-json:check"
-        - ":embulk-input-config:check"
-        - ":embulk-input-file:check"
-        - ":embulk-output-file:check"
-        - ":embulk-output-null:check"
-        - ":embulk-output-stdout:check"
-        - ":embulk-parser-csv:check"
-        - ":embulk-parser-json:check"
     steps:
     - name: Set Git's core.autocrlf to false for Windows before checkout
       run: git config --global core.autocrlf false
@@ -41,7 +21,8 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: 8
-        distribution: "zulu"
+        distribution: "temurin"
+        cache: "gradle"
 
     # GitHub Actions on Windows set environment variables TMP and TEMP with a legacy DOS 8.3 filename: "C:\Users\RUNNER~1\..."
     # On the other hand, "embulk-input-file" expects a long filename (LFN) on Windows.
@@ -56,6 +37,5 @@ jobs:
     - name: Override TEMP to use Windows' long filename (LFN)
       run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       if: matrix.os == 'windows-latest'
-
-    - name: Build and test
-      run: ./gradlew ${{ matrix.gradle_task }}
+    - name: Check all plugins
+      run: ./gradlew --stacktrace check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macOS-latest
+        # - macOS-latest  # https://github.com/embulk/embulk-standards/issues/16
         - windows-latest
     steps:
     - name: Set Git's core.autocrlf to false for Windows before checkout

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ subprojects {
     }
 
     afterEvaluate { project ->
+        rootProject.check.dependsOn project.check
         rootProject.release.dependsOn project.publishMavenPublicationToMavenCentralRepository
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group = "org.embulk"
-version = "0.10.35-SNAPSHOT"
+version = "0.10.36-SNAPSHOT"
 
 task releaseCheck {
     doFirst {


### PR DESCRIPTION
As filed an Issue in embulk/embulk-parser-csv#4, its tests on GitHub Actions stopped working on macOS for some unknown reason. (Hours to finish only on macOS, but still failing.)

2b95eb3f820b6e522fe3e8ae9234c8b9af9408bf is only updating the version number, no any other changes. So, it's something wrong with GitHub Actions.

Through an effort to making the situation better,
* Migrated to OpenJDK 8 Eclipse Temurin, instead of Zulu.
* Changed to test all plugins in one GitHub Actions job, per OS.
  * Because downloading Gradle and dependencies looked taking time on macOS. (Still not working though.)
