### PR TITLE
Refactor and cleanup CsvTokenizer

### DIFF
--- a/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
+++ b/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvTokenizer.java
@@ -26,17 +26,487 @@ import org.embulk.spi.DataException;
 import org.embulk.util.text.LineDecoder;
 
 public class CsvTokenizer {
-    static enum RecordState {
+    public CsvTokenizer(final LineDecoder input, final CsvParserPlugin.PluginTask task) {
+        final String delimiter = task.getDelimiter();
+        if (delimiter.length() == 0) {
+            throw new ConfigException("Empty delimiter is not allowed");
+        } else {
+            this.delimiterChar = delimiter.charAt(0);
+            if (delimiter.length() > 1) {
+                this.delimiterFollowingString = delimiter.substring(1);
+            } else {
+                this.delimiterFollowingString = null;
+            }
+        }
+        this.quote = task.getQuoteChar().orElse(CsvParserPlugin.QuoteCharacter.noQuote()).getCharacter();
+        this.escape = task.getEscapeChar().orElse(CsvParserPlugin.EscapeCharacter.noEscape()).getCharacter();
+        this.newline = task.getNewline().getString();
+        this.trimIfNotQuoted = task.getTrimIfNotQuoted();
+        this.quotesInQuotedFields = task.getQuotesInQuotedFields();
+        if (this.trimIfNotQuoted && this.quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_ONLY_RFC4180_ESCAPED) {
+            // The combination makes some syntax very ambiguous such as:
+            //     val1,  \"\"val2\"\"  ,val3
+            throw new ConfigException("[quotes_in_quoted_fields != ACCEPT_ONLY_RFC4180_ESCAPED] is not allowed to specify with [trim_if_not_quoted = true]");
+        }
+        this.maxQuotedSizeLimit = task.getMaxQuotedSizeLimit();
+        this.commentLineMarker = task.getCommentLineMarker().orElse(null);
+        this.nullStringOrNull = task.getNullString().orElse(null);
+        this.quotedValueLines = new ArrayList<>();
+        this.unreadLines = new ArrayDeque<>();
+        this.input = input;
+
+        this.recordState = RecordState.END;  // initial state is end of a record. nextRecord() must be called first
+        this.lineNumber = 0;
+        this.line = null;
+        this.linePos = 0;
+        this.wasQuotedColumn = false;
+    }
+
+    public static class InvalidFormatException extends DataException {
+        public InvalidFormatException(final String message) {
+            super(message);
+        }
+    }
+
+    public static class InvalidValueException extends DataException {
+        public InvalidValueException(final String message) {
+            super(message);
+        }
+    }
+
+    public static class QuotedSizeLimitExceededException extends InvalidValueException {
+        public QuotedSizeLimitExceededException(final String message) {
+            super(message);
+        }
+    }
+
+    public class TooManyColumnsException extends InvalidFormatException {
+        public TooManyColumnsException(final String message) {
+            super(message);
+        }
+    }
+
+    public class TooFewColumnsException extends InvalidFormatException {
+        public TooFewColumnsException(final String message) {
+            super(message);
+        }
+    }
+
+    public long getCurrentLineNumber() {
+        return this.lineNumber;
+    }
+
+    public boolean skipHeaderLine() {
+        final boolean skipped = this.input.poll() != null;
+        if (skipped) {
+            this.lineNumber++;
+        }
+        return skipped;
+    }
+
+    // returns skipped line
+    public String skipCurrentLine() {
+        final String skippedLine;
+        if (this.quotedValueLines.isEmpty()) {
+            skippedLine = this.line;
+        } else {
+            // recover lines of quoted value
+            skippedLine = this.quotedValueLines.remove(0);  // TODO optimize performance
+            this.unreadLines.addAll(this.quotedValueLines);
+            this.lineNumber -= this.quotedValueLines.size();
+            if (this.line != null) {
+                this.unreadLines.add(this.line);
+                this.lineNumber -= 1;
+            }
+            this.quotedValueLines.clear();
+        }
+        this.recordState = RecordState.END;
+        return skippedLine;
+    }
+
+    public boolean nextFile() {
+        final boolean next = this.input.nextFile();
+        if (next) {
+            this.lineNumber = 0;
+        }
+        return next;
+    }
+
+    // used by guess-csv
+    public boolean nextRecord() {
+        return this.nextRecord(true);
+    }
+
+    public boolean nextRecord(final boolean skipEmptyLine) {
+        // If at the end of record, read the next line and initialize the state
+        if (this.recordState != RecordState.END) {
+            throw new TooManyColumnsException("Too many columns");
+        }
+
+        final boolean hasNext = this.nextLine(skipEmptyLine);
+        if (hasNext) {
+            this.recordState = RecordState.NOT_END;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean nextLine(final boolean skipEmptyLine) {
+        while (true) {
+            if (!this.unreadLines.isEmpty()) {
+                this.line = this.unreadLines.removeFirst();
+            } else {
+                this.line = this.input.poll();
+                if (this.line == null) {
+                    return false;
+                }
+            }
+            this.linePos = 0;
+            this.lineNumber++;
+
+            final boolean skip =
+                    skipEmptyLine && (this.line.isEmpty() || (this.commentLineMarker != null && this.line.startsWith(this.commentLineMarker)));
+            if (!skip) {
+                return true;
+            }
+        }
+    }
+
+    public boolean hasNextColumn() {
+        return this.recordState == RecordState.NOT_END;
+    }
+
+    public String nextColumn() {
+        if (!this.hasNextColumn()) {
+            throw new TooFewColumnsException("Too few columns");
+        }
+
+        // reset last state
+        this.wasQuotedColumn = false;
+        this.quotedValueLines.clear();
+
+        // local state
+        int valueStartPos = this.linePos;
+        int valueEndPos = 0;  // initialized by VALUE state and used by LAST_TRIM_OR_VALUE and
+        StringBuilder quotedValue = null;  // initial by VALUE or FIRST_TRIM state and used by QUOTED_VALUE state
+        ColumnState columnState = ColumnState.BEGIN;
+
+        while (true) {
+            final char c = nextChar();
+
+            switch (columnState) {
+                case BEGIN:
+                    // TODO optimization: state is BEGIN only at the first character of a column.
+                    //      this block can be out of the looop.
+                    if (this.isDelimiter(c)) {
+                        // empty value
+                        if (this.delimiterFollowingString == null) {
+                            return "";
+                        } else if (this.isDelimiterFollowingFrom(this.linePos)) {
+                            this.linePos += this.delimiterFollowingString.length();
+                            return "";
+                        }
+                        // not a delimiter
+                    }
+                    if (this.isEndOfLine(c)) {
+                        // empty value
+                        this.recordState = RecordState.END;
+                        return "";
+
+                    } else if (this.isSpace(c) && this.trimIfNotQuoted) {
+                        columnState = ColumnState.FIRST_TRIM;
+
+                    } else if (this.isQuote(c)) {
+                        valueStartPos = this.linePos;  // == 1
+                        this.wasQuotedColumn = true;
+                        quotedValue = new StringBuilder();
+                        columnState = ColumnState.QUOTED_VALUE;
+
+                    } else {
+                        columnState = ColumnState.VALUE;
+                    }
+                    break;
+
+                case FIRST_TRIM:
+                    if (this.isDelimiter(c)) {
+                        // empty value
+                        if (this.delimiterFollowingString == null) {
+                            return "";
+                        } else if (this.isDelimiterFollowingFrom(this.linePos)) {
+                            this.linePos += this.delimiterFollowingString.length();
+                            return "";
+                        }
+                        // not a delimiter
+                    }
+                    if (this.isEndOfLine(c)) {
+                        // empty value
+                        this.recordState = RecordState.END;
+                        return "";
+
+                    } else if (this.isQuote(c)) {
+                        // column has heading spaces and quoted. TODO should this be rejected?
+                        valueStartPos = this.linePos;
+                        this.wasQuotedColumn = true;
+                        quotedValue = new StringBuilder();
+                        columnState = ColumnState.QUOTED_VALUE;
+
+                    } else if (this.isSpace(c)) {
+                        // skip this character
+
+                    } else {
+                        valueStartPos = this.linePos - 1;
+                        columnState = ColumnState.VALUE;
+                    }
+                    break;
+
+                case VALUE:
+                    if (this.isDelimiter(c)) {
+                        if (this.delimiterFollowingString == null) {
+                            return this.line.substring(valueStartPos, this.linePos - 1);
+                        } else if (this.isDelimiterFollowingFrom(this.linePos)) {
+                            final String value = this.line.substring(valueStartPos, this.linePos - 1);
+                            this.linePos += this.delimiterFollowingString.length();
+                            return value;
+                        }
+                        // not a delimiter
+                    }
+                    if (this.isEndOfLine(c)) {
+                        this.recordState = RecordState.END;
+                        return this.line.substring(valueStartPos, this.linePos);
+
+                    } else if (this.isSpace(c) && this.trimIfNotQuoted) {
+                        valueEndPos = this.linePos - 1;  // this is possibly end of value
+                        columnState = ColumnState.LAST_TRIM_OR_VALUE;
+
+                    // TODO not implemented yet foo""bar""baz -> [foo, bar, baz].append
+                    //} else if (this.isQuote(c)) {
+                    //    // In RFC4180, If fields are not enclosed with double quotes, then
+                    //    // double quotes may not appear inside the fields. But they are often
+                    //    // included in the fields. We should care about them later.
+
+                    } else {
+                        // keep VALUE state
+                    }
+                    break;
+
+                case LAST_TRIM_OR_VALUE:
+                    if (this.isDelimiter(c)) {
+                        if (this.delimiterFollowingString == null) {
+                            return this.line.substring(valueStartPos, valueEndPos);
+                        } else if (this.isDelimiterFollowingFrom(this.linePos)) {
+                            this.linePos += this.delimiterFollowingString.length();
+                            return this.line.substring(valueStartPos, valueEndPos);
+                        } else {
+                            // not a delimiter
+                        }
+                    }
+                    if (this.isEndOfLine(c)) {
+                        this.recordState = RecordState.END;
+                        return this.line.substring(valueStartPos, valueEndPos);
+
+                    } else if (this.isSpace(c)) {
+                        // keep LAST_TRIM_OR_VALUE state
+
+                    } else {
+                        // this spaces are not trailing spaces. go back to VALUE state
+                        columnState = ColumnState.VALUE;
+                    }
+                    break;
+
+                case QUOTED_VALUE:
+                    if (this.isEndOfLine(c)) {
+                        // multi-line quoted value
+                        quotedValue.append(this.line.substring(valueStartPos, this.linePos));
+                        quotedValue.append(this.newline);
+                        this.quotedValueLines.add(this.line);
+                        if (!this.nextLine(false)) {
+                            throw new InvalidValueException("Unexpected end of line during parsing a quoted value");
+                        }
+                        valueStartPos = 0;
+
+                    } else if (this.isQuote(c)) {
+                        final char next = this.peekNextChar();
+                        final char nextNext = this.peekNextNextChar();
+                        if (this.isQuote(next)
+                                && (this.quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS
+                                        || (!this.isDelimiter(nextNext) && !this.isEndOfLine(nextNext)))) {
+                            // Escaped by preceding it with another quote.
+                            // A quote just before a delimiter or an end of line is recognized as a functional quote,
+                            // not just as a non-escaped stray "quote character" included the field, even if
+                            // ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS is specified.
+                            quotedValue.append(this.line.substring(valueStartPos, this.linePos));
+                            valueStartPos = ++this.linePos;
+                        } else if (this.quotesInQuotedFields == QuotesInQuotedFields.ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS
+                                && !(this.isDelimiter(next) || this.isEndOfLine(next))) {
+                            // A non-escaped stray "quote character" in the field is processed as a regular character
+                            // if ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS is specified,
+                            if ((this.linePos - valueStartPos) + quotedValue.length() > this.maxQuotedSizeLimit) {
+                                throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size (" + this.maxQuotedSizeLimit + ")");
+                            }
+                        } else {
+                            quotedValue.append(this.line.substring(valueStartPos, this.linePos - 1));
+                            columnState = ColumnState.AFTER_QUOTED_VALUE;
+                        }
+
+                    } else if (this.isEscape(c)) {  // isQuote must be checked first in case of this.quote == this.escape
+                        // In RFC 4180, CSV's escape char is '\"'. But '\\' is often used.
+                        final char next = this.peekNextChar();
+                        if (this.isEndOfLine(c)) {
+                            // escape end of line. TODO assuming multi-line quoted value without newline?
+                            quotedValue.append(this.line.substring(valueStartPos, this.linePos));
+                            this.quotedValueLines.add(this.line);
+                            if (!this.nextLine(false)) {
+                                throw new InvalidValueException("Unexpected end of line during parsing a quoted value");
+                            }
+                            valueStartPos = 0;
+                        } else if (this.isQuote(next) || this.isEscape(next)) { // escaped quote
+                            quotedValue.append(this.line.substring(valueStartPos, this.linePos - 1));
+                            quotedValue.append(next);
+                            valueStartPos = ++this.linePos;
+                        }
+
+                    } else {
+                        if ((this.linePos - valueStartPos) + quotedValue.length() > this.maxQuotedSizeLimit) {
+                            throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size (" + this.maxQuotedSizeLimit + ")");
+                        }
+                        // keep QUOTED_VALUE state
+                    }
+                    break;
+
+                case AFTER_QUOTED_VALUE:
+                    if (this.isDelimiter(c)) {
+                        if (this.delimiterFollowingString == null) {
+                            return quotedValue.toString();
+                        } else if (this.isDelimiterFollowingFrom(this.linePos)) {
+                            this.linePos += this.delimiterFollowingString.length();
+                            return quotedValue.toString();
+                        }
+                        // not a delimiter
+                    }
+                    if (this.isEndOfLine(c)) {
+                        this.recordState = RecordState.END;
+                        return quotedValue.toString();
+
+                    } else if (this.isSpace(c)) {
+                        // column has trailing spaces and quoted. TODO should this be rejected?
+
+                    } else {
+                        throw new InvalidValueException(String.format("Unexpected extra character '%c' after a value quoted by '%c'", c, this.quote));
+                    }
+                    break;
+
+                default:
+                    assert false;
+            }
+        }
+    }
+
+    public String nextColumnOrNull() {
+        final String v = this.nextColumn();
+        if (this.nullStringOrNull == null) {
+            if (v.isEmpty()) {
+                if (this.wasQuotedColumn) {
+                    return "";
+                } else {
+                    return null;
+                }
+            } else {
+                return v;
+            }
+        } else {
+            if (v.equals(this.nullStringOrNull)) {
+                return null;
+            } else {
+                return v;
+            }
+        }
+    }
+
+    public boolean wasQuotedColumn() {
+        return this.wasQuotedColumn;
+    }
+
+    private char nextChar() {
+        if (this.line == null) {
+            throw new IllegalStateException("nextColumn is called after end of file");
+        }
+
+        if (this.linePos >= this.line.length()) {
+            return END_OF_LINE;
+        } else {
+            return this.line.charAt(this.linePos++);
+        }
+    }
+
+    private char peekNextChar() {
+        if (this.line == null) {
+            throw new IllegalStateException("peekNextChar is called after end of file");
+        }
+
+        if (this.linePos >= this.line.length()) {
+            return END_OF_LINE;
+        } else {
+            return this.line.charAt(this.linePos);
+        }
+    }
+
+    private char peekNextNextChar() {
+        if (this.line == null) {
+            throw new IllegalStateException("peekNextNextChar is called after end of file");
+        }
+
+        if (this.linePos + 1 >= this.line.length()) {
+            return END_OF_LINE;
+        } else {
+            return this.line.charAt(this.linePos + 1);
+        }
+    }
+
+    private boolean isSpace(final char c) {
+        return c == ' ';
+    }
+
+    private boolean isDelimiterFollowingFrom(final int pos) {
+        if (this.line.length() < pos + this.delimiterFollowingString.length()) {
+            return false;
+        }
+        for (int i = 0; i < this.delimiterFollowingString.length(); i++) {
+            if (this.delimiterFollowingString.charAt(i) != this.line.charAt(pos + i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isDelimiter(final char c) {
+        return c == this.delimiterChar;
+    }
+
+    private boolean isEndOfLine(final char c) {
+        return c == END_OF_LINE;
+    }
+
+    private boolean isQuote(final char c) {
+        return this.quote != NO_QUOTE && c == this.quote;
+    }
+
+    private boolean isEscape(final char c) {
+        return this.escape != NO_ESCAPE && c == this.escape;
+    }
+
+    private static enum RecordState {
         NOT_END, END,
     }
 
-    static enum ColumnState {
+    private static enum ColumnState {
         BEGIN, VALUE, QUOTED_VALUE, AFTER_QUOTED_VALUE, FIRST_TRIM, LAST_TRIM_OR_VALUE,
     }
 
-    private static final char END_OF_LINE = '\0';
     static final char NO_QUOTE = '\0';
     static final char NO_ESCAPE = '\0';
+
+    private static final char END_OF_LINE = '\0';
 
     private final char delimiterChar;
     private final String delimiterFollowingString;
@@ -49,473 +519,12 @@ public class CsvTokenizer {
     private final String commentLineMarker;
     private final LineDecoder input;
     private final String nullStringOrNull;
+    private final List<String> quotedValueLines;
+    private final Deque<String> unreadLines;
 
-    private RecordState recordState = RecordState.END;  // initial state is end of a record. nextRecord() must be called first
-    private long lineNumber = 0;
-
-    private String line = null;
-    private int linePos = 0;
-    private boolean wasQuotedColumn = false;
-    private List<String> quotedValueLines = new ArrayList<>();
-    private Deque<String> unreadLines = new ArrayDeque<>();
-
-    public CsvTokenizer(LineDecoder input, CsvParserPlugin.PluginTask task) {
-        String delimiter = task.getDelimiter();
-        if (delimiter.length() == 0) {
-            throw new ConfigException("Empty delimiter is not allowed");
-        } else {
-            this.delimiterChar = delimiter.charAt(0);
-            if (delimiter.length() > 1) {
-                delimiterFollowingString = delimiter.substring(1);
-            } else {
-                delimiterFollowingString = null;
-            }
-        }
-        quote = task.getQuoteChar().orElse(CsvParserPlugin.QuoteCharacter.noQuote()).getCharacter();
-        escape = task.getEscapeChar().orElse(CsvParserPlugin.EscapeCharacter.noEscape()).getCharacter();
-        newline = task.getNewline().getString();
-        trimIfNotQuoted = task.getTrimIfNotQuoted();
-        quotesInQuotedFields = task.getQuotesInQuotedFields();
-        if (trimIfNotQuoted && quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_ONLY_RFC4180_ESCAPED) {
-            // The combination makes some syntax very ambiguous such as:
-            //     val1,  \"\"val2\"\"  ,val3
-            throw new ConfigException("[quotes_in_quoted_fields != ACCEPT_ONLY_RFC4180_ESCAPED] is not allowed to specify with [trim_if_not_quoted = true]");
-        }
-        maxQuotedSizeLimit = task.getMaxQuotedSizeLimit();
-        commentLineMarker = task.getCommentLineMarker().orElse(null);
-        nullStringOrNull = task.getNullString().orElse(null);
-        this.input = input;
-    }
-
-    public long getCurrentLineNumber() {
-        return lineNumber;
-    }
-
-    public boolean skipHeaderLine() {
-        boolean skipped = input.poll() != null;
-        if (skipped) {
-            lineNumber++;
-        }
-        return skipped;
-    }
-
-    // returns skipped line
-    public String skipCurrentLine() {
-        String skippedLine;
-        if (quotedValueLines.isEmpty()) {
-            skippedLine = line;
-        } else {
-            // recover lines of quoted value
-            skippedLine = quotedValueLines.remove(0);  // TODO optimize performance
-            unreadLines.addAll(quotedValueLines);
-            lineNumber -= quotedValueLines.size();
-            if (line != null) {
-                unreadLines.add(line);
-                lineNumber -= 1;
-            }
-            quotedValueLines.clear();
-        }
-        recordState = RecordState.END;
-        return skippedLine;
-    }
-
-    public boolean nextFile() {
-        boolean next = input.nextFile();
-        if (next) {
-            lineNumber = 0;
-        }
-        return next;
-    }
-
-    // used by guess-csv
-    public boolean nextRecord() {
-        return nextRecord(true);
-    }
-
-    public boolean nextRecord(boolean skipEmptyLine) {
-        // If at the end of record, read the next line and initialize the state
-        if (recordState != RecordState.END) {
-            throw new TooManyColumnsException("Too many columns");
-        }
-
-        boolean hasNext = nextLine(skipEmptyLine);
-        if (hasNext) {
-            recordState = RecordState.NOT_END;
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private boolean nextLine(boolean skipEmptyLine) {
-        while (true) {
-            if (!unreadLines.isEmpty()) {
-                line = unreadLines.removeFirst();
-            } else {
-                line = input.poll();
-                if (line == null) {
-                    return false;
-                }
-            }
-            linePos = 0;
-            lineNumber++;
-
-            boolean skip = skipEmptyLine && (line.isEmpty() || (commentLineMarker != null && line.startsWith(commentLineMarker)));
-            if (!skip) {
-                return true;
-            }
-        }
-    }
-
-    public boolean hasNextColumn() {
-        return recordState == RecordState.NOT_END;
-    }
-
-    public String nextColumn() {
-        if (!hasNextColumn()) {
-            throw new TooFewColumnsException("Too few columns");
-        }
-
-        // reset last state
-        wasQuotedColumn = false;
-        quotedValueLines.clear();
-
-        // local state
-        int valueStartPos = linePos;
-        int valueEndPos = 0;  // initialized by VALUE state and used by LAST_TRIM_OR_VALUE and
-        StringBuilder quotedValue = null;  // initial by VALUE or FIRST_TRIM state and used by QUOTED_VALUE state
-        ColumnState columnState = ColumnState.BEGIN;
-
-        while (true) {
-            final char c = nextChar();
-
-            switch (columnState) {
-                case BEGIN:
-                    // TODO optimization: state is BEGIN only at the first character of a column.
-                    //      this block can be out of the looop.
-                    if (isDelimiter(c)) {
-                        // empty value
-                        if (delimiterFollowingString == null) {
-                            return "";
-                        } else if (isDelimiterFollowingFrom(linePos)) {
-                            linePos += delimiterFollowingString.length();
-                            return "";
-                        }
-                        // not a delimiter
-                    }
-                    if (isEndOfLine(c)) {
-                        // empty value
-                        recordState = RecordState.END;
-                        return "";
-
-                    } else if (isSpace(c) && trimIfNotQuoted) {
-                        columnState = ColumnState.FIRST_TRIM;
-
-                    } else if (isQuote(c)) {
-                        valueStartPos = linePos;  // == 1
-                        wasQuotedColumn = true;
-                        quotedValue = new StringBuilder();
-                        columnState = ColumnState.QUOTED_VALUE;
-
-                    } else {
-                        columnState = ColumnState.VALUE;
-                    }
-                    break;
-
-                case FIRST_TRIM:
-                    if (isDelimiter(c)) {
-                        // empty value
-                        if (delimiterFollowingString == null) {
-                            return "";
-                        } else if (isDelimiterFollowingFrom(linePos)) {
-                            linePos += delimiterFollowingString.length();
-                            return "";
-                        }
-                        // not a delimiter
-                    }
-                    if (isEndOfLine(c)) {
-                        // empty value
-                        recordState = RecordState.END;
-                        return "";
-
-                    } else if (isQuote(c)) {
-                        // column has heading spaces and quoted. TODO should this be rejected?
-                        valueStartPos = linePos;
-                        wasQuotedColumn = true;
-                        quotedValue = new StringBuilder();
-                        columnState = ColumnState.QUOTED_VALUE;
-
-                    } else if (isSpace(c)) {
-                        // skip this character
-
-                    } else {
-                        valueStartPos = linePos - 1;
-                        columnState = ColumnState.VALUE;
-                    }
-                    break;
-
-                case VALUE:
-                    if (isDelimiter(c)) {
-                        if (delimiterFollowingString == null) {
-                            return line.substring(valueStartPos, linePos - 1);
-                        } else if (isDelimiterFollowingFrom(linePos)) {
-                            String value = line.substring(valueStartPos, linePos - 1);
-                            linePos += delimiterFollowingString.length();
-                            return value;
-                        }
-                        // not a delimiter
-                    }
-                    if (isEndOfLine(c)) {
-                        recordState = RecordState.END;
-                        return line.substring(valueStartPos, linePos);
-
-                    } else if (isSpace(c) && trimIfNotQuoted) {
-                        valueEndPos = linePos - 1;  // this is possibly end of value
-                        columnState = ColumnState.LAST_TRIM_OR_VALUE;
-
-                    // TODO not implemented yet foo""bar""baz -> [foo, bar, baz].append
-                    //} else if (isQuote(c)) {
-                    //    // In RFC4180, If fields are not enclosed with double quotes, then
-                    //    // double quotes may not appear inside the fields. But they are often
-                    //    // included in the fields. We should care about them later.
-
-                    } else {
-                        // keep VALUE state
-                    }
-                    break;
-
-                case LAST_TRIM_OR_VALUE:
-                    if (isDelimiter(c)) {
-                        if (delimiterFollowingString == null) {
-                            return line.substring(valueStartPos, valueEndPos);
-                        } else if (isDelimiterFollowingFrom(linePos)) {
-                            linePos += delimiterFollowingString.length();
-                            return line.substring(valueStartPos, valueEndPos);
-                        } else {
-                            // not a delimiter
-                        }
-                    }
-                    if (isEndOfLine(c)) {
-                        recordState = RecordState.END;
-                        return line.substring(valueStartPos, valueEndPos);
-
-                    } else if (isSpace(c)) {
-                        // keep LAST_TRIM_OR_VALUE state
-
-                    } else {
-                        // this spaces are not trailing spaces. go back to VALUE state
-                        columnState = ColumnState.VALUE;
-                    }
-                    break;
-
-                case QUOTED_VALUE:
-                    if (isEndOfLine(c)) {
-                        // multi-line quoted value
-                        quotedValue.append(line.substring(valueStartPos, linePos));
-                        quotedValue.append(newline);
-                        quotedValueLines.add(line);
-                        if (!nextLine(false)) {
-                            throw new InvalidValueException("Unexpected end of line during parsing a quoted value");
-                        }
-                        valueStartPos = 0;
-
-                    } else if (isQuote(c)) {
-                        char next = peekNextChar();
-                        final char nextNext = peekNextNextChar();
-                        if (isQuote(next)
-                                && (quotesInQuotedFields != QuotesInQuotedFields.ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS
-                                        || (!isDelimiter(nextNext) && !isEndOfLine(nextNext)))) {
-                            // Escaped by preceding it with another quote.
-                            // A quote just before a delimiter or an end of line is recognized as a functional quote,
-                            // not just as a non-escaped stray "quote character" included the field, even if
-                            // ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS is specified.
-                            quotedValue.append(line.substring(valueStartPos, linePos));
-                            valueStartPos = ++linePos;
-                        } else if (quotesInQuotedFields == QuotesInQuotedFields.ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS
-                                && !(isDelimiter(next) || isEndOfLine(next))) {
-                            // A non-escaped stray "quote character" in the field is processed as a regular character
-                            // if ACCEPT_STRAY_QUOTES_ASSUMING_NO_DELIMITERS_IN_FIELDS is specified,
-                            if ((linePos - valueStartPos) + quotedValue.length() > maxQuotedSizeLimit) {
-                                throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size (" + maxQuotedSizeLimit + ")");
-                            }
-                        } else {
-                            quotedValue.append(line.substring(valueStartPos, linePos - 1));
-                            columnState = ColumnState.AFTER_QUOTED_VALUE;
-                        }
-
-                    } else if (isEscape(c)) {  // isQuote must be checked first in case of quote == escape
-                        // In RFC 4180, CSV's escape char is '\"'. But '\\' is often used.
-                        char next = peekNextChar();
-                        if (isEndOfLine(c)) {
-                            // escape end of line. TODO assuming multi-line quoted value without newline?
-                            quotedValue.append(line.substring(valueStartPos, linePos));
-                            quotedValueLines.add(line);
-                            if (!nextLine(false)) {
-                                throw new InvalidValueException("Unexpected end of line during parsing a quoted value");
-                            }
-                            valueStartPos = 0;
-                        } else if (isQuote(next) || isEscape(next)) { // escaped quote
-                            quotedValue.append(line.substring(valueStartPos, linePos - 1));
-                            quotedValue.append(next);
-                            valueStartPos = ++linePos;
-                        }
-
-                    } else {
-                        if ((linePos - valueStartPos) + quotedValue.length() > maxQuotedSizeLimit) {
-                            throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size (" + maxQuotedSizeLimit + ")");
-                        }
-                        // keep QUOTED_VALUE state
-                    }
-                    break;
-
-                case AFTER_QUOTED_VALUE:
-                    if (isDelimiter(c)) {
-                        if (delimiterFollowingString == null) {
-                            return quotedValue.toString();
-                        } else if (isDelimiterFollowingFrom(linePos)) {
-                            linePos += delimiterFollowingString.length();
-                            return quotedValue.toString();
-                        }
-                        // not a delimiter
-                    }
-                    if (isEndOfLine(c)) {
-                        recordState = RecordState.END;
-                        return quotedValue.toString();
-
-                    } else if (isSpace(c)) {
-                        // column has trailing spaces and quoted. TODO should this be rejected?
-
-                    } else {
-                        throw new InvalidValueException(String.format("Unexpected extra character '%c' after a value quoted by '%c'", c, quote));
-                    }
-                    break;
-
-                default:
-                    assert false;
-            }
-        }
-    }
-
-    public String nextColumnOrNull() {
-        String v = nextColumn();
-        if (nullStringOrNull == null) {
-            if (v.isEmpty()) {
-                if (wasQuotedColumn) {
-                    return "";
-                } else {
-                    return null;
-                }
-            } else {
-                return v;
-            }
-        } else {
-            if (v.equals(nullStringOrNull)) {
-                return null;
-            } else {
-                return v;
-            }
-        }
-    }
-
-    public boolean wasQuotedColumn() {
-        return wasQuotedColumn;
-    }
-
-    private char nextChar() {
-        if (line == null) {
-            throw new IllegalStateException("nextColumn is called after end of file");
-        }
-
-        if (linePos >= line.length()) {
-            return END_OF_LINE;
-        } else {
-            return line.charAt(linePos++);
-        }
-    }
-
-    private char peekNextChar() {
-        if (line == null) {
-            throw new IllegalStateException("peekNextChar is called after end of file");
-        }
-
-        if (linePos >= line.length()) {
-            return END_OF_LINE;
-        } else {
-            return line.charAt(linePos);
-        }
-    }
-
-    private char peekNextNextChar() {
-        if (line == null) {
-            throw new IllegalStateException("peekNextNextChar is called after end of file");
-        }
-
-        if (linePos + 1 >= line.length()) {
-            return END_OF_LINE;
-        } else {
-            return line.charAt(linePos + 1);
-        }
-    }
-
-    private boolean isSpace(char c) {
-        return c == ' ';
-    }
-
-    private boolean isDelimiterFollowingFrom(int pos) {
-        if (line.length() < pos + delimiterFollowingString.length()) {
-            return false;
-        }
-        for (int i = 0; i < delimiterFollowingString.length(); i++) {
-            if (delimiterFollowingString.charAt(i) != line.charAt(pos + i)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean isDelimiter(char c) {
-        return c == delimiterChar;
-    }
-
-    private boolean isEndOfLine(char c) {
-        return c == END_OF_LINE;
-    }
-
-    private boolean isQuote(char c) {
-        return quote != NO_QUOTE && c == quote;
-    }
-
-    private boolean isEscape(char c) {
-        return escape != NO_ESCAPE && c == escape;
-    }
-
-    public static class InvalidFormatException extends DataException {
-        public InvalidFormatException(String message) {
-            super(message);
-        }
-    }
-
-    public static class InvalidValueException extends DataException {
-        public InvalidValueException(String message) {
-            super(message);
-        }
-    }
-
-    public static class QuotedSizeLimitExceededException extends InvalidValueException {
-        public QuotedSizeLimitExceededException(String message) {
-            super(message);
-        }
-    }
-
-    public class TooManyColumnsException extends InvalidFormatException {
-        public TooManyColumnsException(String message) {
-            super(message);
-        }
-    }
-
-    public class TooFewColumnsException extends InvalidFormatException {
-        public TooFewColumnsException(String message) {
-            super(message);
-        }
-    }
+    private RecordState recordState;
+    private long lineNumber;
+    private String line;
+    private int linePos;
+    private boolean wasQuotedColumn;
 }


### PR DESCRIPTION
I made an independent `embulk-util-csv` (https://github.com/embulk/embulk-util-csv), but it didn't work compatibly in #11. It looks to be some difference in Exception structures. Hard to investigate all the causes, and difficult to prove a fix is correct.

Instead, I'm going to have another try by refactoring them inside `embulk-parser-csv` iteratively, then move them to `embulk-util-csv` overridden.

Upcoming PRs would be the refactoring.
* #20 
* #21 
* #22 
* #23 