### PR TITLE
Remove grgit from build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id "java"
     id "java-library"
     id "maven-publish"
-    id "org.ajoberstar.grgit" version "4.1.1"
     id "org.embulk.embulk-plugins" version "0.4.2" apply false
 }
 
@@ -18,19 +17,6 @@ task releaseCheck {
         if (rootProject.version.endsWith("-SNAPSHOT")) {
             throw new GradleException("Not for release. The version in build.gradle is SNAPSHOT: ${rootProject.version}")
         }
-        def grgit = org.ajoberstar.grgit.Grgit.open(dir: "${rootProject.projectDir}")
-        if (!grgit.status().clean) {
-            throw new GradleException("Not for release. The working tree is dirty.")
-        }
-        def described = grgit.describe(commit: "HEAD").toString().trim()
-        if (described != "v${rootProject.version}") {
-            throw new GradleException("Not for release. git-describe returned a name different from the version in build.gradle: ${described} v.s. v${rootProject.version}")
-        }
-        if (described.contains("-")) {
-            // HEAD may not be tagged with annotation properly.
-            throw new GradleException("Not for release. git-describe returned a name with a hyphen: ${described}")
-        }
-        // TODO: Revisit if we would check the format of tag annotation.
     }
     doLast {
         println "Ready. Run 'release' task."


### PR DESCRIPTION
Even though `grgit` says 4.1.1 should be available via the Gradle Plugin Portan and Maven Central (*1), we actually got a JCenter-related error (*2).

(*1) https://github.com/ajoberstar/grgit/tree/4.1.1#newest-versions-are-on-maven-central

(*2) https://github.com/embulk/embulk-standards/actions/runs/4466362930/jobs/7844457982

```
* What went wrong:
A problem occurred configuring root project 'embulk-standards'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not resolve org.ajoberstar.grgit:grgit-core:4.1.1.
     Required by:
         project : > org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin:4.1.1 > org.ajoberstar.grgit:grgit-gradle:4.1.1
      > Could not resolve org.ajoberstar.grgit:grgit-core:4.1.1.
         > Could not get resource 'https://plugins.gradle.org/m2/org/ajoberstar/grgit/grgit-core/4.1.1/grgit-core-4.1.1.pom'.
            > Could not GET 'https://jcenter.bintray.com/org/ajoberstar/grgit/grgit-core/4.1.1/grgit-core-4.1.1.pom'.
               > Remote host terminated the handshake
```

Our use of `grgit` was not too heavy. It's not mandatory. It's time to remove it.