### PR TITLE
Add CODEOWNERS to be @embulk/core-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@embulk/core-team


### PR DESCRIPTION
`embulk-standards` is bundled with the Embulk executable package. It should be reviewed by @embulk/core-team like: https://github.com/embulk/embulk