### PR TITLE
Fix for explicit null in CSV quote and escape

### DIFF
--- a/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
+++ b/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
@@ -485,8 +485,8 @@ public class CsvParserPlugin implements ParserPlugin {
     private static CsvTokenizer.Builder buildCsvTokenizerBuilder(final PluginTask task) {
         try {
             final CsvTokenizer.Builder builder = CsvTokenizer.builder(task.getDelimiter());
-            task.getQuoteChar().ifPresent(q -> builder.setQuote(q.getCharacter()));
-            task.getEscapeChar().ifPresent(e -> builder.setEscape(e.getCharacter()));
+            builder.setQuote(task.getQuoteChar().orElse(QuoteCharacter.noQuote()).getCharacter());
+            builder.setEscape(task.getEscapeChar().orElse(EscapeCharacter.noEscape()).getCharacter());
             builder.setNewline(task.getNewline().getString());
             if (task.getTrimIfNotQuoted()) {
                 builder.enableTrimIfNotQuoted();

--- a/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
+++ b/embulk-parser-csv/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
@@ -478,6 +478,10 @@ public class CsvParserPlugin implements ParserPlugin {
         }
     }
 
+    static CsvTokenizer.Builder buildCsvTokenizerBuilderForTesting(final PluginTask task) {
+        return buildCsvTokenizerBuilder(task);
+    }
+
     private static CsvTokenizer.Builder buildCsvTokenizerBuilder(final PluginTask task) {
         try {
             final CsvTokenizer.Builder builder = CsvTokenizer.builder(task.getDelimiter());

--- a/embulk-parser-csv/src/test/java/org/embulk/parser/csv/TestCsvParserPlugin.java
+++ b/embulk-parser-csv/src/test/java/org/embulk/parser/csv/TestCsvParserPlugin.java
@@ -26,6 +26,7 @@ import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.csv.CsvTokenizer;
 import org.embulk.util.text.Newline;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,5 +86,139 @@ public class TestCsvParserPlugin {
         assertEquals("\t", task.getDelimiter());
         assertEquals(Optional.of(new CsvParserPlugin.QuoteCharacter('\\')), task.getQuoteChar());
         assertEquals(true, task.getAllowOptionalColumns());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerQuoteBackslash() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .set("quote", "\\")
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals('\\', builder.peekQuote());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerQuoteQuotation() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .set("quote", "\"")
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals('\"', builder.peekQuote());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerQuoteUnspecified() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals('\"', builder.peekQuote());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerQuoteNull() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .setNested("quote", null)  // #setNested is needed to set null
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals(CsvTokenizer.NO_QUOTE, builder.peekQuote());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerEscapeBackslash() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .set("escape", "\\")
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals('\\', builder.peekEscape());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerEscapeSlash() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .set("escape", "/")
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals('/', builder.peekEscape());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerEscapeUnspecified() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals('\\', builder.peekEscape());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testCsvTokenizerEscapeNull() {
+        final ConfigSource config = CONFIG_MAPPER_FACTORY.newConfigSource()
+                .set("charset", "utf-16")
+                .set("newline", "LF")
+                .set("header_line", true)
+                .set("delimiter", "\t")
+                .setNested("escape", null)  // #setNested is needed to set null
+                .set("columns", ImmutableList.of(ImmutableMap.of("name", "id", "type", "string")));
+        final CsvParserPlugin.PluginTask task =
+                CONFIG_MAPPER_FACTORY.createConfigMapper().map(config, CsvParserPlugin.PluginTask.class);
+
+        final CsvTokenizer.Builder builder = CsvParserPlugin.buildCsvTokenizerBuilderForTesting(task);
+        assertEquals(CsvTokenizer.NO_ESCAPE, builder.peekEscape());
     }
 }


### PR DESCRIPTION
CSV parser's behavior was not compatible with older versions when `null` is specified explicitly for `quote` or `escape`.

cdd9ce31bf984d549162b23780e6cc58e9ea4f37 is to confirm it fails by tests, and 5d3d3a7210ef4ec5d993b17216a66cb06520d04f fixes it.